### PR TITLE
Fixes for errors when doing "make test" on a clean checkout

### DIFF
--- a/scripts/download_movielens.sh
+++ b/scripts/download_movielens.sh
@@ -10,10 +10,12 @@ read DUMMY
 echo "This may take a while ..."
 echo
 
+mkdir -p data
+
 # download MovieLens data
 wget --output-document=data/ml-100k.zip  http://www.grouplens.org/system/files/ml-100k.zip
 wget --output-document=data/ml-1m.zip    http://www.grouplens.org/system/files/ml-1m.zip
-wget --output-document=data/ml-10m.zip   http://www.grouplens.org/sites/www.grouplens.org/external_files/data/ml-10m.zip
+wget --output-document=data/ml-10m.zip   http://files.grouplens.org/papers/ml-10m.zip
 
 cd data
 


### PR DESCRIPTION
The "data" directory does not exist in a clean checkout, so create it if it does not exist.

http://www.grouplens.org/sites/www.grouplens.org/external_files/data/ml-10m.zip gives a 404. http://files.grouplens.org/papers/ml-10m.zip is where the file is at.
