### PR TITLE
Bump up version in nuspec to 3.11

### DIFF
--- a/src/MyMediaLite/MyMediaLite.nuspec
+++ b/src/MyMediaLite/MyMediaLite.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>MyMediaLite</id>
-    <version>3.10</version>
+    <version>3.11</version>
     <authors>Zeno Gantner, Steffen Rendle, Lucas Drumond</authors>
     <owners>Zeno Gantner, Greg Najda</owners>
     <description>Recommender system library for CLR (.NET)</description>


### PR DESCRIPTION
Bump up the version in the .nuspec file used for creating nuget packages to 3.11 to go with the 3.11 release.