### PR TITLE
Repair displaying fit in ItemCrossValidation

### DIFF
--- a/src/MyMediaLite/Eval/ItemsCrossValidation.cs
+++ b/src/MyMediaLite/Eval/ItemsCrossValidation.cs
@@ -108,6 +108,8 @@ namespace MyMediaLite.Eval
 				avg_results[key] /= split.NumberOfFolds;
 			avg_results["num_users"] /= split.NumberOfFolds;
 			avg_results["num_items"] /= split.NumberOfFolds;
+			avg_results["fit"] /= split.NumberOfFolds;
+
 
 			return avg_results;
 		}

--- a/src/MyMediaLite/Eval/ItemsCrossValidation.cs
+++ b/src/MyMediaLite/Eval/ItemsCrossValidation.cs
@@ -108,6 +108,7 @@ namespace MyMediaLite.Eval
 				avg_results[key] /= split.NumberOfFolds;
 			avg_results["num_users"] /= split.NumberOfFolds;
 			avg_results["num_items"] /= split.NumberOfFolds;
+			if(compute_fit)
 			avg_results["fit"] /= split.NumberOfFolds;
 
 


### PR DESCRIPTION
fit was NumberOfFolds times bigger that output fit should be. 
(For 10fold cross validation, fit was e.g. 6.543 instead of 0.6543)

Fit value divided by NumberOfFolds in DoCrossValidation method of ItemCrossValidation.