### PR TITLE
Update RatingCrossValidationSplit.cs

### DIFF
--- a/src/MyMediaLite/Data/RatingCrossValidationSplit.cs
+++ b/src/MyMediaLite/Data/RatingCrossValidationSplit.cs
@@ -67,12 +67,12 @@ namespace MyMediaLite.Data
 			}
 
 			// assign indices to folds
-			foreach (int i in random_indices)
+			for (int i = 0; i < random_indices.Count; i++)
 				for (int j = 0; j < num_folds; j++)
 					if (j == i % num_folds)
-						test_indices[j].Add(i);
+						test_indices[j].Add(random_indices[i]);
 					else
-						train_indices[j].Add(i);
+						train_indices[j].Add(random_indices[i]);
 
 			// create split data structures
 			Train = new List<IRatings>((int) num_folds);


### PR DESCRIPTION
Problem:
Assigning indices to the folds is not really random. Easily reproducible by checking the results on a simple recommender, such as the ItemAverage, and k-fold CV. Fold[i] always has the same result over multiple runs.

Reason:
Each int in random_indices will eventually get assigned to the same fold as you iterate over the content of random_indices (the entity indices).

Fix:
Iterate over indices of random_indices instead.