### PR TITLE
Fixed Ignore First Line Bug in call of Read method.

### DIFF
--- a/src/MyMediaLite/IO/ItemData.cs
+++ b/src/MyMediaLite/IO/ItemData.cs
@@ -42,7 +42,7 @@ namespace MyMediaLite.IO
 			return Wrap.FormatException<IPosOnlyFeedback>(filename, delegate() {
 				using ( var reader = new StreamReader(filename) )
 				{
-					var feedback_data = (ISerializable) Read(reader, user_mapping, item_mapping);
+					var feedback_data = (ISerializable) Read(reader, user_mapping, item_mapping, ignore_first_line);
 					if (FileSerializer.Should(user_mapping, item_mapping) && FileSerializer.CanWrite(binary_filename))
 						feedback_data.Serialize(binary_filename);
 					return (IPosOnlyFeedback) feedback_data;


### PR DESCRIPTION
I found a bug with the **ignore_first_line parameter** through the command line.
The _Read method with filename parameter_ calls the _Read method with reader parameter_ with no ignore_first_line parameter from the first method (always getting default value for this parameter).

I fix this bug and I'm sending only this file to merge.