### PR TITLE
Fix bug in CoClustering algorithm

### DIFF
--- a/src/MyMediaLite/RatingPrediction/CoClustering.cs
+++ b/src/MyMediaLite/RatingPrediction/CoClustering.cs
@@ -252,6 +252,10 @@ namespace MyMediaLite.RatingPrediction
 			var item_cluster_counts = new int[NumItemClusters];
 			var cocluster_counts    = new int[NumUserClusters, NumItemClusters];
 
+			this.user_cluster_averages = new float[NumUserClusters];
+			this.item_cluster_averages = new float[NumItemClusters];
+			this.cocluster_averages    = new Matrix<float>(NumUserClusters, NumItemClusters);
+
 			for (int i = 0; i < ratings.Count; i++)
 			{
 				int user_id = ratings.Users[i];


### PR DESCRIPTION
Hi Zeno,

I know this algorithm is labeled as obsolete but I was trying to implement it myself and I think there's a slight mistake in the `ComputeClusterAverages`method because the cluster averages are not reset to zero before updating. In the end this hardly changes anything, it's like computing a mean over `n + 1` elements instead of `n` elements and as `n` is high there's almost no difference.

Thanks!